### PR TITLE
Remove paper categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,12 +193,6 @@ permalink: /
 
          <p class="text">Papers must describe original work, be written and presented in English, and must not substantially overlap with papers that have been published or that are simultaneously submitted to a journal, conference, or workshop with refereed proceedings. Work that already appeared in unpublished or informally published workshop proceedings may be submitted (please contact the PC chairs in case of questions).</p>
 
-         <p class="text">Papers can be submitted in the following categories:</p>
-         <ul>
-            <li>technical papers</li>
-            <li>system descriptions</li>
-         </ul>
-
          <p class="text">Full papers should consist of up to 12 pages, system descriptions or short papers should be no longer than 6 pages (including references). Formatting should follow the Springer LNCS guidelines which are available <em><a href="https://www.springer.com/gp/computer-science/lncs/conference-proceedings-guidelines" target="_blank">here</a></em>, along with formatting templates and style files.</p>
 
          <p class="text">Authors should submit an electronic copy of the full paper in PDF. Papers should be submitted via the <em>Easychair submission website</em> for WLP 2022. The submission link will be made available soon!</p>


### PR DESCRIPTION
IMO, the two categories are in the CfP for historical reasons. I would suggest to just remove them. RFC @maweki.